### PR TITLE
Added CMake & Travis configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Build directory
+bld

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/fifo"]
+	path = external/fifo
+	url = https://github.com/spoorcc/fifo.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: cpp
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - cmake
+
+compiler:
+  - gcc
+  - clang
+
+script:
+  - mkdir -p bld
+  - cd bld
+  - cmake ..
+  - make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(ServiceDispatcher)
+
+cmake_minimum_required(VERSION 2.8)
+
+include_directories(inc)
+include_directories(external/fifo/inc)
+
+add_subdirectory(external/fifo)
+add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# ServiceDispatcher
+
+[![Build Status](https://travis-ci.org/spoorcc/ServiceDispatcher.svg?branch=master)](https://travis-ci.org/spoorcc/ServiceDispatcher)
+
+Service Dispatcher
+
+## Build instructions
+
+    mkdir -p bld
+    cd bld
+    cmake ..
+    make

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(sdq SHARED ServiceDispatcherQueue.c)
+target_link_libraries(sdq fifo)
+
+add_library(sdr SHARED ServiceDispatcherRouter.c)


### PR DESCRIPTION
Because ServiceDispatcher depends on tom360v/fifo I added this as submodule in new folder called external. Because that also works on CMake, this is build directly together with ServiceDispatcher.

When merging this Pull Request update any spoorcc mentions to tom360v (travis shield in README.md)